### PR TITLE
Add SwiftLint to project

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,84 @@
+# SwiftLint configuration file for Lambda School
+#
+# For any changes to this file, tag all team members in the PR for quick approval or discussion
+#
+# See current configuration with:
+# swiftlint rules
+#
+# See documentation for the latest (master branch) rules at: https://github.com/realm/SwiftLint/blob/master/Rules.md
+# and https://github.com/realm/SwiftLint for an example of options in this file
+#
+disabled_rules: # rule identifiers to exclude from running
+  - class_delegate_protocol # This breaks if you have a delegate protocol that inherits from a class-bound protocol (see: SwiftyTables DataSourceDelegate)
+  - identifier_name
+  - redundant_objc_attribute 
+  - todo
+  - trailing_comma
+  - vertical_parameter_alignment # does not work with tab indentation: https://github.com/realm/SwiftLint/issues/1573
+
+excluded: # paths to ignore during linting.
+  - Carthage
+  - Swift Style Guide.playground
+  - fastlane/*
+  - Pods
+
+opt_in_rules:
+  - anyobject_protocol
+  - closure_spacing
+  - collection_alignment
+  - conditional_returns_on_newline
+  - convenience_type
+  - empty_count
+  - empty_xctest_method
+  - explicit_init
+  - fatal_error_message
+  - first_where
+  - function_default_parameter_at_end
+  - identical_operands
+  - implicit_return
+  - joined_default_parameter
+  - last_where
+  - legacy_random
+  - let_var_whitespace
+  - modifier_order
+  - multiline_arguments
+  - multiline_parameters
+  - operator_usage_whitespace
+  - overridden_super_call
+  - private_outlet
+  - prohibited_super_call
+  - redundant_nil_coalescing
+  - static_operator
+  - toggle_bool
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - untyped_error_in_catch
+  - unused_control_flow_label
+  - vertical_parameter_alignment_on_call
+  - xct_specific_matcher
+
+  # Experimental
+  - explicit_self
+  - unused_import
+  - unused_private_declaration
+
+# Rule options
+conditional_returns_on_newline:
+  if_only: true
+file_length:
+  warning: 800
+  error: 1000
+line_length:
+  warning: 160
+  ignores_comments: true
+  ignores_interpolated_strings: true
+multiline_arguments:
+  only_enforce_after_first_closure_on_first_line: true
+type_body_length:
+  warning: 400
+  error: 700
+vertical_whitespace:
+  max_empty_lines: 2
+trailing_whitespace:
+  ignores_empty_lines: true
+

--- a/EcoSoapBank.xcodeproj/project.pbxproj
+++ b/EcoSoapBank.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 				466C426C249A8748007D033E /* Sources */,
 				466C426D249A8748007D033E /* Frameworks */,
 				466C426E249A8748007D033E /* Resources */,
+				9998716224E1AD26000A993E /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -357,6 +358,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9998716224E1AD26000A993E /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		466C426C249A8748007D033E /* Sources */ = {

--- a/EcoSoapBank/Helpers/SwiftUI+Extensions.swift
+++ b/EcoSoapBank/Helpers/SwiftUI+Extensions.swift
@@ -5,6 +5,7 @@
 //  Created by Jon Bash on 2020-08-07.
 //  Copyright © 2020 Spencer Curtis. All rights reserved.
 //
+// swiftlint:disable shorthand_operator
 
 import SwiftUI
 

--- a/autocorrect.yml
+++ b/autocorrect.yml
@@ -1,0 +1,14 @@
+# This file will be run to auto-correct certain swiftlint rules before swiftlint is run with the standard .swiftlint.yml configuration file.
+#
+# An enhancement to do this has been requested here: https://github.com/realm/SwiftLint/issues/1451
+# Once done, that enhancement might obsolete this approach.
+
+# Only add rules here you want to auto-correct
+whitelist_rules: 
+- trailing_whitespace
+- trailing_semicolon
+- trailing_newline
+excluded: # paths to ignore during linting.
+  - Carthage
+  - Pods
+  


### PR DESCRIPTION
- Added build phase for SwiftLint
- Added [Lambda School's SwiftLint rules](https://github.com/LambdaSchool/ios-swiftlint-rules)
- Disabled operator shorthand rule in SwiftUI+Extensions.swift file
    - The custom implementation of `+=` in that file requires an explicit `x = y + x` format, which makes SwiftLint unhappy, so the affected rule is disabled just for that file.