### PR TITLE
Swiftlint fixes; mostly basic formatting

### DIFF
--- a/EcoSoapBank/App/AppDelegate.swift
+++ b/EcoSoapBank/App/AppDelegate.swift
@@ -11,16 +11,19 @@ import OktaAuth
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {        
-        return true
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 }
-

--- a/EcoSoapBank/App/AppFlowCoordinator.swift
+++ b/EcoSoapBank/App/AppFlowCoordinator.swift
@@ -34,4 +34,3 @@ class AppFlowCoordinator: FlowCoordinator {
         window.makeKeyAndVisible()
     }
 }
-

--- a/EcoSoapBank/App/SceneDelegate.swift
+++ b/EcoSoapBank/App/SceneDelegate.swift
@@ -31,7 +31,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let context = URLContexts.first else { return }
 
         let url = context.url
-        ProfileController.shared.oktaAuth.receiveCredentials(fromCallbackURL: url) { (result) in
+        ProfileController.shared.oktaAuth.receiveCredentials(fromCallbackURL: url) { result in
             
             let notificationName: Notification.Name
             do {
@@ -48,4 +48,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 }
-

--- a/EcoSoapBank/Login/AddProfileViewController.swift
+++ b/EcoSoapBank/Login/AddProfileViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol AddProfileDelegate: class {
+protocol AddProfileDelegate: AnyObject {
     func profileWasAdded()
 }
 

--- a/EcoSoapBank/Login/AddProfileViewController.swift
+++ b/EcoSoapBank/Login/AddProfileViewController.swift
@@ -16,10 +16,10 @@ class AddProfileViewController: UIViewController {
 
     // MARK: - Properties and Outlets
     
-    @IBOutlet weak var nameTextField: UITextField!
-    @IBOutlet weak var emailTextField: UITextField!
-    @IBOutlet weak var avatarURLTextField: UITextField!
-    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet private weak var nameTextField: UITextField!
+    @IBOutlet private weak var emailTextField: UITextField!
+    @IBOutlet private weak var avatarURLTextField: UITextField!
+    @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
     
     weak var delegate: AddProfileDelegate?
     

--- a/EcoSoapBank/Login/LoginViewController.swift
+++ b/EcoSoapBank/Login/LoginViewController.swift
@@ -38,10 +38,11 @@ class LoginViewController: UIViewController {
     
     private func alertUserOfExpiredCredentials(_ notification: Notification) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.presentSimpleAlert(with: "Your Okta credentials have expired",
-                           message: "Please sign in again",
-                           preferredStyle: .alert,
-                           dismissText: "Dimiss")
+            self.presentSimpleAlert(
+                with: "Your Okta credentials have expired",
+                message: "Please sign in again",
+                preferredStyle: .alert,
+                dismissText: "Dimiss")
         }
     }
     
@@ -52,7 +53,7 @@ class LoginViewController: UIViewController {
     }
     
     private func checkForExistingProfile() {
-        profileController.checkForExistingAuthenticatedUserProfile { [weak self] (exists) in
+        profileController.checkForExistingAuthenticatedUserProfile { [weak self] exists in
             
             guard let self = self,
                 self.presentedViewController == nil else { return }

--- a/EcoSoapBank/Login/LoginViewController.swift
+++ b/EcoSoapBank/Login/LoginViewController.swift
@@ -12,20 +12,29 @@ import OktaAuth
 class LoginViewController: UIViewController {
     
     let profileController = ProfileController.shared
+
+    var observers: [NSObjectProtocol] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        NotificationCenter.default.addObserver(forName: .oktaAuthenticationSuccessful,
-                                               object: nil,
-                                               queue: .main,
-                                               using: checkForExistingProfile)
-        
-        NotificationCenter.default.addObserver(forName: .oktaAuthenticationExpired,
-                                               object: nil,
-                                               queue: .main,
-                                               using: alertUserOfExpiredCredentials)
-        
+
+        let authSuccessObserver = NotificationCenter.default.addObserver(
+            forName: .oktaAuthenticationSuccessful,
+            object: nil,
+            queue: .main,
+            using: checkForExistingProfile)
+        let authExpiredObserver = NotificationCenter.default.addObserver(
+            forName: .oktaAuthenticationExpired,
+            object: nil,
+            queue: .main,
+            using: alertUserOfExpiredCredentials)
+        observers.append(contentsOf: [authSuccessObserver, authExpiredObserver])
+    }
+
+    deinit {
+        observers.forEach {
+            NotificationCenter.default.removeObserver($0)
+        }
     }
     
     // MARK: - Actions

--- a/EcoSoapBank/Login/ProfileTabBarViewController.swift
+++ b/EcoSoapBank/Login/ProfileTabBarViewController.swift
@@ -10,13 +10,22 @@ import UIKit
 
 class ProfileTabBarViewController: UITabBarController {
 
+    private var authExpirationObserver: NSObjectProtocol?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        NotificationCenter.default.addObserver(forName: .oktaAuthenticationExpired,
-                                                             object: nil,
-                                                             queue: .main,
-                                                             using: dismissToLogin)
+        authExpirationObserver = NotificationCenter.default.addObserver(
+            forName: .oktaAuthenticationExpired,
+            object: nil,
+            queue: .main,
+            using: dismissToLogin)
+    }
+
+    deinit {
+        if let observer = authExpirationObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
     
     func dismissToLogin(_ notification: Notification) {

--- a/EcoSoapBank/Login/ProfileTabBarViewController.swift
+++ b/EcoSoapBank/Login/ProfileTabBarViewController.swift
@@ -19,7 +19,7 @@ class ProfileTabBarViewController: UITabBarController {
                                                              using: dismissToLogin)
     }
     
-    func dismissToLogin(_ notification: Notification)  {
+    func dismissToLogin(_ notification: Notification) {
         dismiss(animated: true, completion: nil)
     }
 }

--- a/EcoSoapBank/Model Controller/PickupController.swift
+++ b/EcoSoapBank/Model Controller/PickupController.swift
@@ -25,7 +25,7 @@ extension Array where Element == Pickup {
                 readyDate: Date(timeIntervalSinceNow: .days(-10)),
                 pickupDate: Date(timeIntervalSinceNow: .days(-5)),
                 cartons: [
-                    .init(id: 0, product: .bottles, weight: 20),],
+                    .init(id: 0, product: .bottles, weight: 20), ],
                 notes: "notes"),
             Pickup(
                 id: 1,

--- a/EcoSoapBank/Model Controller/ProfileController.swift
+++ b/EcoSoapBank/Model Controller/ProfileController.swift
@@ -53,7 +53,7 @@ class ProfileController {
         
         request.addValue("Bearer \(oktaCredentials.idToken)", forHTTPHeaderField: "Authorization")
         
-        let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
+        let dataTask = URLSession.shared.dataTask(with: request) { data, response, error in
             
             defer {
                 DispatchQueue.main.async {
@@ -113,7 +113,7 @@ class ProfileController {
             return
         }
         
-        getSingleProfile(userID) { (profile) in
+        getSingleProfile(userID) { profile in
             self.authenticatedUserProfile = profile
             DispatchQueue.main.async {
                 completion()
@@ -149,7 +149,7 @@ class ProfileController {
         
         request.addValue("Bearer \(oktaCredentials.idToken)", forHTTPHeaderField: "Authorization")
         
-        let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
+        let dataTask = URLSession.shared.dataTask(with: request) { data, response, error in
             
             var fetchedProfile: Profile?
             
@@ -218,10 +218,9 @@ class ProfileController {
             return
         }
         
-        let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
-            
+        let dataTask = URLSession.shared.dataTask(with: request) { data, response, error in
             var profile = profile
-            
+
             defer {
                 DispatchQueue.main.async {
                     completion(profile)
@@ -311,7 +310,7 @@ class ProfileController {
             return
         }
         
-        let dataTask = URLSession.shared.dataTask(with: request) { (data, response, error) in
+        let dataTask = URLSession.shared.dataTask(with: request) { _, response, error in
             
             defer {
                 DispatchQueue.main.async {
@@ -335,9 +334,9 @@ class ProfileController {
     }
     
     func image(for url: URL, completion: @escaping (UIImage?) -> Void) {
-        let dataTask = URLSession.shared.dataTask(with: url) { (data, _, error) in
+        let dataTask = URLSession.shared.dataTask(with: url) { data, _, error in
             
-            var fetchedImage: UIImage? = nil
+            var fetchedImage: UIImage?
             
             defer {
                 DispatchQueue.main.async {

--- a/EcoSoapBank/Model/Profile.swift
+++ b/EcoSoapBank/Model/Profile.swift
@@ -16,7 +16,7 @@ struct Profile: Codable {
     let avatarURL: URL?
     
     /// Storing the `avatarImage` on the model object itself is fine up to a point due to potentially using too much memory. If you know you will be storing a large amount of images, using a cache and clearing it out after you hit a certain amount of information in it would be better.
-    var avatarImage: UIImage? = nil
+    var avatarImage: UIImage?
     
     enum CodingKeys: String, CodingKey {
         case id

--- a/EcoSoapBank/Profile/ProfileDetailViewController.swift
+++ b/EcoSoapBank/Profile/ProfileDetailViewController.swift
@@ -12,14 +12,14 @@ class ProfileDetailViewController: UIViewController {
     
     // MARK: - Properties and Outlets
     
-    @IBOutlet weak var avatarImageView: UIImageView!
-    @IBOutlet weak var nameLabel: UILabel!
-    @IBOutlet weak var emailLabel: UILabel!
+    @IBOutlet private weak var avatarImageView: UIImageView!
+    @IBOutlet private weak var nameLabel: UILabel!
+    @IBOutlet private weak var emailLabel: UILabel!
     
-    @IBOutlet weak var editStackView: UIStackView!
-    @IBOutlet weak var nameTextField: UITextField!
-    @IBOutlet weak var emailTextField: UITextField!
-    @IBOutlet weak var avatarURLTextField: UITextField!
+    @IBOutlet private weak var editStackView: UIStackView!
+    @IBOutlet private weak var nameTextField: UITextField!
+    @IBOutlet private weak var emailTextField: UITextField!
+    @IBOutlet private weak var avatarURLTextField: UITextField!
     
     var profileController: ProfileController = ProfileController.shared
     var profile: Profile?

--- a/EcoSoapBank/Profile/ProfileDetailViewController.swift
+++ b/EcoSoapBank/Profile/ProfileDetailViewController.swift
@@ -52,7 +52,7 @@ class ProfileDetailViewController: UIViewController {
                 return
         }
         
-        profileController.updateAuthenticatedUserProfile(profile, with: name, email: email, avatarURL: avatarURL) { [weak self] (updatedProfile) in
+        profileController.updateAuthenticatedUserProfile(profile, with: name, email: email, avatarURL: avatarURL) { [weak self] updatedProfile in
             
             guard let self = self else { return }
             self.updateViews(with: updatedProfile)
@@ -96,7 +96,7 @@ class ProfileDetailViewController: UIViewController {
         if let avatarImage = profile.avatarImage {
             avatarImageView.image = avatarImage
         } else if let avatarURL = profile.avatarURL {
-            profileController.image(for: avatarURL, completion: { [weak self] (avatarImage) in
+            profileController.image(for: avatarURL, completion: { [weak self] avatarImage in
                 guard let self = self else { return }
                 
                 self.profile?.avatarImage = avatarImage

--- a/EcoSoapBank/Profile/ProfileListViewController.swift
+++ b/EcoSoapBank/Profile/ProfileListViewController.swift
@@ -52,7 +52,7 @@ class ProfileListViewController: UIViewController {
 extension ProfileListViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return profileController.profiles.count
+        profileController.profiles.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/EcoSoapBank/Profile/ProfileListViewController.swift
+++ b/EcoSoapBank/Profile/ProfileListViewController.swift
@@ -11,7 +11,7 @@ import OktaAuth
 
 class ProfileListViewController: UIViewController {
     
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView!
     
     var profileController = ProfileController.shared
     

--- a/EcoSoapBankTests/EcoSoapBankTests.swift
+++ b/EcoSoapBankTests/EcoSoapBankTests.swift
@@ -18,11 +18,6 @@ class EcoSoapBankTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         measure {

--- a/EcoSoapBankTests/UtilityTests.swift
+++ b/EcoSoapBankTests/UtilityTests.swift
@@ -5,6 +5,7 @@
 //  Created by Jon Bash on 2020-08-07.
 //  Copyright © 2020 Spencer Curtis. All rights reserved.
 //
+// swiftlint:disable nesting
 
 import XCTest
 @testable import EcoSoapBank


### PR DESCRIPTION
Mostly auto-corrected minor formatting stuff, but also includes some refactors to make the linter happier. These methods will likely be removed or vastly changed later as well, since they're mostly from the starter project.

For the NotificationCenter observers, the linter warned that they would need to be hung onto so they could be `remove`d later. Again, this will likely vastly change later.

Other details are in commit comments.