### PR TITLE
Pickups navigation view + infrastructure

### DIFF
--- a/EcoSoapBank.xcodeproj/project.pbxproj
+++ b/EcoSoapBank.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		998913D724DE0C34009ADBC1 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913D624DE0C33009ADBC1 /* Property.swift */; };
 		998913D924DE0C90009ADBC1 /* HospitalityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913D824DE0C90009ADBC1 /* HospitalityService.swift */; };
 		998913DB24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */; };
+		9998716424E1E8C4000A993E /* PickupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9998716324E1E8C4000A993E /* PickupsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		998913D624DE0C33009ADBC1 /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 		998913D824DE0C90009ADBC1 /* HospitalityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HospitalityService.swift; sourceTree = "<group>"; };
 		998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extensions.swift"; sourceTree = "<group>"; };
+		9998716324E1E8C4000A993E /* PickupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickupsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -232,6 +234,7 @@
 			isa = PBXGroup;
 			children = (
 				994E4B7424DDB4A100C12921 /* PickupCoordinator.swift */,
+				9998716324E1E8C4000A993E /* PickupsView.swift */,
 				998913CE24DDFE54009ADBC1 /* PickupHistoryView.swift */,
 				998913D424DE0907009ADBC1 /* PickupListItem.swift */,
 			);
@@ -401,6 +404,7 @@
 				998913CF24DDFE54009ADBC1 /* PickupHistoryView.swift in Sources */,
 				998913D724DE0C34009ADBC1 /* Property.swift in Sources */,
 				46BEB4E924C98DAF00FE0CD1 /* ProfileListViewController.swift in Sources */,
+				9998716424E1E8C4000A993E /* PickupsView.swift in Sources */,
 				998913D124DDFF96009ADBC1 /* PickupController.swift in Sources */,
 				463AD24524CF2CDB00447BB8 /* AddProfileViewController.swift in Sources */,
 				466C4274249A8748007D033E /* AppDelegate.swift in Sources */,

--- a/EcoSoapBank/Helpers/SwiftUI+Extensions.swift
+++ b/EcoSoapBank/Helpers/SwiftUI+Extensions.swift
@@ -10,6 +10,16 @@
 import SwiftUI
 
 
+// MARK: - Image
+
+extension Image {
+    static func plus() -> Image { Image(systemName: "plus") }
+    static func cubeBox() -> Image { Image(systemName: "cube.box") }
+}
+
+
+// MARK: - Text
+
 extension Text {
     static func += (lhs: inout Text, rhs: Text) {
         lhs = lhs + rhs

--- a/EcoSoapBank/Pickups/PickupCoordinator.swift
+++ b/EcoSoapBank/Pickups/PickupCoordinator.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 
 class PickupCoordinator: FlowCoordinator {
-    let pickupController = PickupController()
+    let pickupController = PickupController(dataProvider: MockPickupProvider())
 
     private(set) lazy var rootVC: UIViewController = UIHostingController(
         rootView: PickupHistoryView(pickupController: pickupController))

--- a/EcoSoapBank/Pickups/PickupCoordinator.swift
+++ b/EcoSoapBank/Pickups/PickupCoordinator.swift
@@ -20,3 +20,9 @@ class PickupCoordinator: FlowCoordinator {
         rootVC.tabBarItem = UITabBarItem(tabBarSystemItem: .history, tag: 1)
     }
 }
+
+extension PickupCoordinator: PickupsViewDelegate {
+    func logOut() {
+        preconditionFailure("Requested log out (not yet implemented)")
+    }
+}

--- a/EcoSoapBank/Pickups/PickupCoordinator.swift
+++ b/EcoSoapBank/Pickups/PickupCoordinator.swift
@@ -14,10 +14,14 @@ class PickupCoordinator: FlowCoordinator {
     let pickupController = PickupController(dataProvider: MockPickupProvider())
 
     private(set) lazy var rootVC: UIViewController = UIHostingController(
-        rootView: PickupHistoryView(pickupController: pickupController))
+        rootView: PickupsView(
+            pickupController: pickupController,
+            delegate: self))
 
     func start() {
-        rootVC.tabBarItem = UITabBarItem(tabBarSystemItem: .history, tag: 1)
+        rootVC.tabBarItem = UITabBarItem(
+            tabBarSystemItem: .history,
+            tag: 1)
     }
 }
 

--- a/EcoSoapBank/Pickups/PickupHistoryView.swift
+++ b/EcoSoapBank/Pickups/PickupHistoryView.swift
@@ -25,6 +25,7 @@ struct PickupHistoryView: View {
 
 struct PickupHistoryView_Previews: PreviewProvider {
     static var previews: some View {
-        PickupHistoryView(pickupController: .init())
+        PickupHistoryView(
+            pickupController: .init(dataProvider: MockPickupProvider()))
     }
 }

--- a/EcoSoapBank/Pickups/PickupsView.swift
+++ b/EcoSoapBank/Pickups/PickupsView.swift
@@ -17,6 +17,8 @@ protocol PickupsViewDelegate: AnyObject {
 struct PickupsView: View {
     @ObservedObject private var pickupController: PickupController
 
+    @State private var makingNewPickup = false
+
     private weak var delegate: PickupsViewDelegate?
 
     init(
@@ -30,7 +32,25 @@ struct PickupsView: View {
     var body: some View {
         NavigationView {
             PickupHistoryView(pickupController: pickupController)
+                .navigationBarTitle("Pickup History", displayMode: .inline)
+                .navigationBarItems(
+                    leading: Button(
+                        action: { self.delegate?.logOut() },
+                        label: { Text("Log out") }),
+                    trailing: Button(
+                        action: { self.makingNewPickup = true },
+                        label: newPickupButtonLabel
+                    )
+                )
         }
+    }
+
+    private func newPickupButtonLabel() -> some View {
+        HStack(spacing: 4) {
+            Image.plus()
+            Image.cubeBox()
+        }.padding(4).overlay(RoundedRectangle(cornerRadius: 10).stroke())
+        .accessibility(label: Text("Schedule New Pickup"))
     }
 }
 

--- a/EcoSoapBank/Pickups/PickupsView.swift
+++ b/EcoSoapBank/Pickups/PickupsView.swift
@@ -8,8 +8,24 @@
 
 import SwiftUI
 
+
+protocol PickupsViewDelegate: AnyObject {
+    func logOut()
+}
+
+
 struct PickupsView: View {
     @ObservedObject private var pickupController: PickupController
+
+    private weak var delegate: PickupsViewDelegate?
+
+    init(
+        pickupController: PickupController,
+        delegate: PickupsViewDelegate?
+    ) {
+        self.pickupController = pickupController
+        self.delegate = delegate
+    }
 
     var body: some View {
         NavigationView {

--- a/EcoSoapBank/Pickups/PickupsView.swift
+++ b/EcoSoapBank/Pickups/PickupsView.swift
@@ -33,3 +33,12 @@ struct PickupsView: View {
         }
     }
 }
+
+struct PickupsView_Previews: PreviewProvider {
+    static var previews: some View {
+        PickupsView(
+            pickupController: PickupController(
+                dataProvider: MockPickupProvider()),
+            delegate: nil)
+    }
+}

--- a/EcoSoapBank/Pickups/PickupsView.swift
+++ b/EcoSoapBank/Pickups/PickupsView.swift
@@ -6,4 +6,14 @@
 //  Copyright © 2020 Spencer Curtis. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
+
+struct PickupsView: View {
+    @ObservedObject private var pickupController: PickupController
+
+    var body: some View {
+        NavigationView {
+            PickupHistoryView(pickupController: pickupController)
+        }
+    }
+}

--- a/EcoSoapBank/Pickups/PickupsView.swift
+++ b/EcoSoapBank/Pickups/PickupsView.swift
@@ -1,0 +1,9 @@
+//
+//  PickupsView.swift
+//  EcoSoapBank
+//
+//  Created by Jon Bash on 2020-08-10.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
## What's here (& why)

- Wrapped pickups history view in NavigationView
- Added buttons to nav bar
- Added infrastructure for further pickup-related views

Related Trello card: https://trello.com/c/YZbY3XL4/11-as-a-user-i-can-view-past-and-upcoming-pickups