### PR TITLE
StripeController, CheckoutVC; login bugfix + error handling

### DIFF
--- a/EcoSoapBank.xcodeproj/project.pbxproj
+++ b/EcoSoapBank.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		998913D724DE0C34009ADBC1 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913D624DE0C33009ADBC1 /* Property.swift */; };
 		998913D924DE0C90009ADBC1 /* HospitalityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913D824DE0C90009ADBC1 /* HospitalityService.swift */; };
 		998913DB24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */; };
+		9990F6E124F9B78C00DD16B5 /* StripeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9990F6E024F9B78C00DD16B5 /* StripeController.swift */; };
 		9990F6E524F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9990F6E424F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift */; };
 		9998716424E1E8C4000A993E /* PickupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9998716324E1E8C4000A993E /* PickupsView.swift */; };
 		999CBA3A24F8755E00CDF0F3 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999CBA3924F8755E00CDF0F3 /* LoadingViewController.swift */; };
@@ -278,6 +279,7 @@
 		998913D624DE0C33009ADBC1 /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 		998913D824DE0C90009ADBC1 /* HospitalityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HospitalityService.swift; sourceTree = "<group>"; };
 		998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extensions.swift"; sourceTree = "<group>"; };
+		9990F6E024F9B78C00DD16B5 /* StripeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeController.swift; sourceTree = "<group>"; };
 		9990F6E424F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ErrorAlert.swift"; sourceTree = "<group>"; };
 		9998716324E1E8C4000A993E /* PickupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickupsView.swift; sourceTree = "<group>"; };
 		999CBA3924F8755E00CDF0F3 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 				04FEE1B524E48AB000F51D69 /* ImpactController.swift */,
 				998913D024DDFF96009ADBC1 /* PickupController.swift */,
 				992BB63D24EEE21300638AA4 /* UserController.swift */,
+				9990F6E024F9B78C00DD16B5 /* StripeController.swift */,
 				992BB64624EF08E400638AA4 /* Mock Providers */,
 			);
 			path = "Model Controller";
@@ -918,6 +921,7 @@
 				992BB63A24EDCF1400638AA4 /* PickupDetailViewController.swift in Sources */,
 				04E42DFF24F6C04600D4003E /* Keychain+Okta.swift in Sources */,
 				46BF10BE24D388FF001C6753 /* UIViewController+SimpleAlert.swift in Sources */,
+				9990F6E124F9B78C00DD16B5 /* StripeController.swift in Sources */,
 				049379AB24EB29160084051B /* ImpactHeaderView.swift in Sources */,
 				041E1E8624E1EB580052831D /* Fonts.swift in Sources */,
 				990CA24224DB6C19002B5FA4 /* UIStoryboard+Constants.swift in Sources */,

--- a/EcoSoapBank.xcodeproj/project.pbxproj
+++ b/EcoSoapBank.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		998913D924DE0C90009ADBC1 /* HospitalityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913D824DE0C90009ADBC1 /* HospitalityService.swift */; };
 		998913DB24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */; };
 		9990F6E124F9B78C00DD16B5 /* StripeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9990F6E024F9B78C00DD16B5 /* StripeController.swift */; };
+		9990F6E324F9BFFE00DD16B5 /* CheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9990F6E224F9BFFE00DD16B5 /* CheckoutViewController.swift */; };
 		9990F6E524F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9990F6E424F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift */; };
 		9998716424E1E8C4000A993E /* PickupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9998716324E1E8C4000A993E /* PickupsView.swift */; };
 		999CBA3A24F8755E00CDF0F3 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999CBA3924F8755E00CDF0F3 /* LoadingViewController.swift */; };
@@ -280,6 +281,7 @@
 		998913D824DE0C90009ADBC1 /* HospitalityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HospitalityService.swift; sourceTree = "<group>"; };
 		998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extensions.swift"; sourceTree = "<group>"; };
 		9990F6E024F9B78C00DD16B5 /* StripeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeController.swift; sourceTree = "<group>"; };
+		9990F6E224F9BFFE00DD16B5 /* CheckoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutViewController.swift; sourceTree = "<group>"; };
 		9990F6E424F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ErrorAlert.swift"; sourceTree = "<group>"; };
 		9998716324E1E8C4000A993E /* PickupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickupsView.swift; sourceTree = "<group>"; };
 		999CBA3924F8755E00CDF0F3 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 		994E4B6F24DDAEB700C12921 /* Payment */ = {
 			isa = PBXGroup;
 			children = (
+				9990F6E224F9BFFE00DD16B5 /* CheckoutViewController.swift */,
 			);
 			path = Payment;
 			sourceTree = "<group>";
@@ -945,6 +948,7 @@
 				041E1EA724E22B1E0052831D /* Colors.swift in Sources */,
 				992BB64524EF021600638AA4 /* MockLoginProvider.swift in Sources */,
 				994E4B7924DDB58300C12921 /* UtilityFunctions.swift in Sources */,
+				9990F6E324F9BFFE00DD16B5 /* CheckoutViewController.swift in Sources */,
 				99B6175B24EAF0A20099664B /* SchedulePickupViewController.swift in Sources */,
 				994E4B7724DDB55E00C12921 /* ImpactViewController.swift in Sources */,
 				998913D524DE0907009ADBC1 /* PickupHistoryCell.swift in Sources */,

--- a/EcoSoapBank.xcodeproj/project.pbxproj
+++ b/EcoSoapBank.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		998913D724DE0C34009ADBC1 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913D624DE0C33009ADBC1 /* Property.swift */; };
 		998913D924DE0C90009ADBC1 /* HospitalityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913D824DE0C90009ADBC1 /* HospitalityService.swift */; };
 		998913DB24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */; };
+		9990F6E524F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9990F6E424F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift */; };
 		9998716424E1E8C4000A993E /* PickupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9998716324E1E8C4000A993E /* PickupsView.swift */; };
 		999CBA3A24F8755E00CDF0F3 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999CBA3924F8755E00CDF0F3 /* LoadingViewController.swift */; };
 		999CBA3D24F9AFF100CDF0F3 /* Stripe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 999CBA3C24F9AFF100CDF0F3 /* Stripe.framework */; };
@@ -277,6 +278,7 @@
 		998913D624DE0C33009ADBC1 /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 		998913D824DE0C90009ADBC1 /* HospitalityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HospitalityService.swift; sourceTree = "<group>"; };
 		998913DA24DE1AC6009ADBC1 /* SwiftUI+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftUI+Extensions.swift"; sourceTree = "<group>"; };
+		9990F6E424F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ErrorAlert.swift"; sourceTree = "<group>"; };
 		9998716324E1E8C4000A993E /* PickupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickupsView.swift; sourceTree = "<group>"; };
 		999CBA3924F8755E00CDF0F3 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 		999CBA3C24F9AFF100CDF0F3 /* Stripe.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Stripe.framework; path = Carthage/Build/iOS/Stripe.framework; sourceTree = "<group>"; };
@@ -528,6 +530,7 @@
 				991874D324E4B28900F636FB /* UIView+Subviews.swift */,
 				049379A624EAE9FF0084051B /* UIView+Layout.swift */,
 				992BB64B24F033F100638AA4 /* UISwipeActionsConfiguration+Constants.swift */,
+				9990F6E424F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";

--- a/EcoSoapBank.xcodeproj/project.pbxproj
+++ b/EcoSoapBank.xcodeproj/project.pbxproj
@@ -961,6 +961,7 @@
 				E2D04F9324F0D50600515831 /* Address.swift in Sources */,
 				9998716424E1E8C4000A993E /* PickupsView.swift in Sources */,
 				998913D124DDFF96009ADBC1 /* PickupController.swift in Sources */,
+				9990F6E524F9C8F100DD16B5 /* UIViewController+ErrorAlert.swift in Sources */,
 				466C4274249A8748007D033E /* AppDelegate.swift in Sources */,
 				E2D3030124E5F9B8008A6FAF /* MockDataLoader.swift in Sources */,
 				9983874C24E4657C00450244 /* KeyboardAvoiding.swift in Sources */,

--- a/EcoSoapBank/App/AppFlowCoordinator.swift
+++ b/EcoSoapBank/App/AppFlowCoordinator.swift
@@ -82,25 +82,12 @@ class AppFlowCoordinator: FlowCoordinator {
     // MARK: - Methods
 
     func presentLoginFailAlert(error: Error? = nil) {
-        if let error = error {
-            NSLog("Error occurred: \(error)")
-        }
-        let userError = error as? UserFacingError
         if tabBarController.presentedViewController != nil {
             tabBarController.dismiss(animated: true) { [weak self] in
                 self?.presentLoginFailAlert(error: error)
             }
         }
-        let message = userError?.userFacingDescription
-            ?? "An unknown error occurred while logging in. Please try again."
-        tabBarController.presentSimpleAlert(
-            with: "Login failed",
-            message: message,
-            preferredStyle: .alert,
-            dismissText: "OK"
-        ) { [weak self] _ in
-            self?.loginCoord.start()
-        }
+        tabBarController.presentAlert(for: error)
     }
 
     private func onLoginComplete() {

--- a/EcoSoapBank/App/AppFlowCoordinator.swift
+++ b/EcoSoapBank/App/AppFlowCoordinator.swift
@@ -21,7 +21,7 @@ class AppFlowCoordinator: FlowCoordinator {
     private(set) lazy var loginCoord = LoginCoordinator(
         root: tabBarController,
         userController: userController,
-        onLoginComplete: { [weak self] in self?.onLoginComplete() })
+        onLoginComplete: { [weak self] user in self?.onLoginComplete(withUser: user) })
     private(set) lazy var userController = UserController(dataLoader: userProvider)
 
     // MARK: - Data Providers
@@ -69,8 +69,8 @@ class AppFlowCoordinator: FlowCoordinator {
                     switch result {
                     case .failure(let error):
                         self?.presentLoginFailAlert(error: error)
-                    case .success:
-                        self?.onLoginComplete()
+                    case .success(let user):
+                        self?.onLoginComplete(withUser: user)
                     }
                 }
             }
@@ -90,7 +90,7 @@ class AppFlowCoordinator: FlowCoordinator {
         tabBarController.presentAlert(for: error)
     }
 
-    private func onLoginComplete() {
+    private func onLoginComplete(withUser user: User) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else {
                 var topLevelVC = UIApplication.shared.windows

--- a/EcoSoapBank/Helpers/Errors.swift
+++ b/EcoSoapBank/Helpers/Errors.swift
@@ -9,10 +9,45 @@
 import Foundation
 
 
-/// An error that may be presented to the user.
-protocol UserFacingError: Error {
-    /// A short description of the error to be displayed to the user. Should be short and layperson-friendly.
-    var userFacingDescription: String? { get }
+struct CustomError: LocalizedError {
+    let errorDescription: String
+    let recoverySuggestion: String
+}
+
+
+struct ErrorMessage {
+    let title: String
+    let message: String
+    let error: Error?
+
+    private static let fallbackTitle = "An unknown error occurred."
+    private static let fallbackMessage = "Please contact the developer for more information."
+
+    init(title: String, message: String, error: Error? = nil) {
+        self.title = title
+        self.message = message
+        if let error = error {
+            self.error = error
+        } else {
+            self.error = CustomError(errorDescription: title,
+                                     recoverySuggestion: message)
+        }
+    }
+
+    init(error: Error? = nil) {
+        if let error = error as? LocalizedError {
+            self.init(
+                title: error.errorDescription ?? Self.fallbackTitle,
+                message: error.recoverySuggestion
+                    ?? error.failureReason
+                    ?? Self.fallbackMessage
+            )
+        } else {
+            self.init(title: Self.fallbackTitle,
+                      message: Self.fallbackMessage,
+                      error: error)
+        }
+    }
 }
 
 

--- a/EcoSoapBank/Helpers/UIKit/UIViewController+ErrorAlert.swift
+++ b/EcoSoapBank/Helpers/UIKit/UIViewController+ErrorAlert.swift
@@ -1,0 +1,61 @@
+//
+//  UIViewController+ErrorAlert.swift
+//  EcoSoapBank
+//
+//  Created by Jon Bash on 2020-08-28.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import UIKit
+
+
+extension ErrorMessage {
+    func alertController() -> UIAlertController {
+        UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert)
+    }
+}
+
+
+extension UIAlertAction {
+    static var okay: UIAlertAction {
+        UIAlertAction(title: "OK", style: .default, handler: nil)
+    }
+}
+
+
+extension UIViewController {
+    func presentAlert(
+        for errorMessage: ErrorMessage,
+        actions: [UIAlertAction] = [],
+        animated: Bool = true,
+        onComplete: (() -> Void)? = nil
+    ) {
+        if let error = errorMessage.error {
+            NSLog("An error occurred: \(error)")
+        } else {
+            NSLog("An unknown error occurred.")
+        }
+        let alert = errorMessage.alertController()
+        if actions.isEmpty {
+            alert.addAction(.okay)
+        } else {
+            actions.forEach(alert.addAction(_:))
+        }
+
+        (self.presentedViewController ?? self).present(alert,
+                                                       animated: animated,
+                                                       completion: onComplete)
+    }
+
+    func presentAlert(
+        for error: Error?,
+        actions: [UIAlertAction] = [],
+        animated: Bool = true,
+        onComplete: (() -> Void)? = nil
+    ) {
+        self.presentAlert(for: ErrorMessage(error: error))
+    }
+}

--- a/EcoSoapBank/Login/LoginCoordinator.swift
+++ b/EcoSoapBank/Login/LoginCoordinator.swift
@@ -62,14 +62,14 @@ class LoginCoordinator: FlowCoordinator {
 
     private var cancellables = Set<AnyCancellable>()
 
-    private var onLoginComplete: () -> Void
+    private var onLoginComplete: (User) -> Void
 
     // MARK: - Init/Start
 
     init(
         root: UIViewController,
         userController: UserController,
-        onLoginComplete: @escaping () -> Void
+        onLoginComplete: @escaping (User) -> Void
     ) {
         self.rootVC = root
         self.userController = userController
@@ -89,7 +89,6 @@ class LoginCoordinator: FlowCoordinator {
             .store(in: &cancellables)
         userController.$user
             .compactMap { $0 }
-            .map { _ in () }
             .sink(receiveValue: onLoginComplete)
             .store(in: &cancellables)
     }

--- a/EcoSoapBank/Login/LoginCoordinator.swift
+++ b/EcoSoapBank/Login/LoginCoordinator.swift
@@ -10,7 +10,7 @@ import UIKit
 import Combine
 
 
-enum LoginError: UserFacingError {
+enum LoginError: LocalizedError {
     case notLoggedIn
     case loginFailed
     case expiredCredentials
@@ -18,7 +18,7 @@ enum LoginError: UserFacingError {
     case other(Error)
     case unknown
 
-    var userFacingDescription: String? {
+    var errorDescription: String? {
         switch self {
         case .notLoggedIn:
             return "You're currently logged out."
@@ -29,7 +29,24 @@ enum LoginError: UserFacingError {
         case .oktaFailure:
             return "There's a problem with Okta's service."
         case .other(let otherError):
-            return (otherError as? UserFacingError)?.userFacingDescription
+            return (otherError as? LocalizedError)?.errorDescription
+        case .unknown:
+            return nil
+        }
+    }
+
+    var recoverySuggestion: String? {
+        switch self {
+        case .notLoggedIn:
+            return "Please log in to proceed."
+        case .loginFailed:
+            return "Please try again; did you enter the correct username/password?"
+        case .expiredCredentials:
+            return "Please log in again to renew your credentials."
+        case .oktaFailure:
+            return "Please try again later; sorry for the inconvenience."
+        case .other(let otherError):
+            return (otherError as? LocalizedError)?.recoverySuggestion
         case .unknown:
             return nil
         }
@@ -90,16 +107,7 @@ extension LoginCoordinator {
     }
 
     private func alertUserOfLoginError(_ error: Error) {
-        let message = "Please log in."
-        let title = (error as? UserFacingError)?.userFacingDescription
-                        ?? "Login failed"
-        (self.rootVC.presentedViewController ?? self.rootVC)?
-            .presentSimpleAlert(
-                with: title,
-                message: message,
-                preferredStyle: .alert,
-                dismissText: "OK",
-                completionUponDismissal: { [weak self] _ in self?.start() })
+        (self.rootVC.presentedViewController ?? self.rootVC)?.presentAlert(for: error)
     }
 }
 

--- a/EcoSoapBank/Model Controller/StripeController.swift
+++ b/EcoSoapBank/Model Controller/StripeController.swift
@@ -1,0 +1,78 @@
+//
+//  StripeController.swift
+//  EcoSoapBank
+//
+//  Created by Jon Bash on 2020-08-28.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation
+import Stripe
+
+
+enum StripeError: Error {
+    case invalidURL
+    case unknown
+}
+
+
+class StripeController: NSObject {
+    var backendURL: URL
+
+    private(set) var customerContext: STPCustomerContext!
+
+    private let user: User
+
+    init(user: User, backendURL: URL) {
+        self.user = user
+        self.backendURL = backendURL
+
+        super.init()
+
+        self.customerContext = STPCustomerContext(keyProvider: self)
+    }
+
+    func newPaymentContext() -> STPPaymentContext {
+        configure(STPPaymentContext(customerContext: customerContext)) {
+            $0.paymentAmount = 500 // TODO: replace with actual price
+        }
+    }
+}
+
+// MARK: - Customer Key Provider
+
+extension StripeController: STPCustomerEphemeralKeyProvider {
+    func createCustomerKey(
+        withAPIVersion apiVersion: String,
+        completion: @escaping STPJSONResponseCompletionBlock
+    ) {
+        let urlComponents = configure(URLComponents(
+            url: backendURL.appendingPathComponent("ephemeral_keys"),
+            resolvingAgainstBaseURL: false)
+        ) {
+            $0?.queryItems = [URLQueryItem(name: "api_version",
+                                           value: apiVersion)]
+        }
+        guard let url = urlComponents?.url else {
+            return completion(nil, StripeError.invalidURL)
+        }
+        let request = configure(URLRequest(url: url)) {
+            $0.httpMethod = "POST"
+        }
+
+        URLSession.shared.dataTask(with: request
+        ) { data, response, error in
+            guard
+                let response = response as? HTTPURLResponse,
+                response.statusCode == 200,
+                let data = data,
+                let json = (try? JSONSerialization
+                    .jsonObject(with: data, options: []) as? [String: Any])
+                    as [String: Any]??
+                else {
+                    return completion(nil, error ?? StripeError.unknown)
+            }
+            completion(json, nil)
+        }.resume()
+    }
+}

--- a/EcoSoapBank/Network Controller/GraphQLController.swift
+++ b/EcoSoapBank/Network Controller/GraphQLController.swift
@@ -22,12 +22,12 @@ class GraphQLController {
     // MARK: - Properties
 
     private let session: DataLoader
-    private let url = URL(string: "http://35.208.9.187:9094/ios-api-1/")!
+    static let url = URL(string: "http://35.208.9.187:9094/ios-api-1/")!
     private var token: String? { Keychain.Okta.getToken() }
 
     // Setting up the url request
     private lazy var request: URLRequest = {
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: Self.url)
         request.httpMethod = HTTPMethod.post.rawValue
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         return request

--- a/EcoSoapBank/Payment/CheckoutViewController.swift
+++ b/EcoSoapBank/Payment/CheckoutViewController.swift
@@ -1,0 +1,150 @@
+//
+//  CheckoutViewController.swift
+//  EcoSoapBank
+//
+//  Created by Jon Bash on 2020-08-28.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import UIKit
+import Stripe
+
+
+class CheckoutViewController: UIViewController {
+
+    private let stripeController: StripeController
+    private let paymentContext: STPPaymentContext
+
+    private let currencyFormatter = configure(NumberFormatter()) {
+        $0.numberStyle = .currency
+    }
+
+    // MARK: - Subviews
+
+    private let priceLabel = configure(UILabel()) {
+        //        $0.font = .muli(style: .title1)
+        $0.text = ""
+    }
+
+    private let paymentOptionsButton = configure(ESBButton()) {
+        $0.setTitle("Select Payment Type", for: .normal)
+        $0.titleLabel?.font = .muli(style: .title2)
+        $0.addTarget(self, action: #selector(choosePayment(_:)), for: .touchUpInside)
+    }
+
+    private let paymentIcon = UIImageView()
+    private let paymentLabel = configure(UILabel()) {
+        $0.font = .muli(style: .title1)
+        $0.text = "Paying by: "
+    }
+    private lazy var paymentStack = configure(UIStackView()) {
+        $0.axis = .horizontal
+        $0.alignment = .leading
+        $0.distribution = .fill
+        $0.spacing = 8
+        $0.isHidden = true
+
+        [paymentIcon, paymentLabel].forEach($0.addArrangedSubview(_:))
+    }
+
+    private var mainStack = configure(UIStackView()) {
+        $0.axis = .vertical
+        $0.alignment = .center
+        $0.distribution = .equalSpacing
+        $0.spacing = 8
+    }
+
+    // MARK: - Init / Lifecycle
+
+    init(stripeController: StripeController) {
+        self.stripeController = stripeController
+        self.paymentContext = stripeController.newPaymentContext()
+        super.init(nibName: nil, bundle: nil)
+
+        paymentContext.delegate = self
+        paymentContext.hostViewController = self
+
+
+        priceLabel.text = stringFromContextAmount()
+    }
+
+    @available(*, unavailable, message: "Use init(stripeController:)")
+    required init?(coder: NSCoder) {
+        fatalError("`init(coder:)` not implemented. Use `init(stripeController:)`.")
+    }
+
+    override func loadView() {
+        view = UIView()
+        view.backgroundColor = .systemBackground
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.constrainNewSubviewToCenter(mainStack)
+        [priceLabel, paymentOptionsButton, paymentLabel]
+            .forEach(mainStack.addArrangedSubview(_:))
+    }
+}
+
+// MARK: - Actions
+
+extension CheckoutViewController {
+    @objc func choosePayment(_ sender: Any?) {
+        paymentContext.presentPaymentOptionsViewController()
+    }
+
+    func stringFromContextAmount() -> String {
+        let decimal = Decimal(paymentContext.paymentAmount) * 0.01
+        return currencyFormatter.string(from: decimal as NSDecimalNumber)!
+    }
+}
+
+// MARK: - Payment Context Delegate
+
+extension CheckoutViewController: STPPaymentContextDelegate {
+    func paymentContextDidChange(_ paymentContext: STPPaymentContext) {
+        if paymentContext.loading {
+            present(LoadingViewController(), animated: true, completion: nil)
+        } else if presentedViewController as? LoadingViewController != nil {
+            dismiss(animated: true, completion: nil)
+        }
+
+        paymentLabel.text = paymentContext.selectedPaymentOption?.label
+        paymentIcon.image = paymentContext.selectedPaymentOption?.image
+        paymentStack.isHidden = (paymentContext.selectedPaymentOption != nil)
+
+    }
+
+    func paymentContext(
+        _ paymentContext: STPPaymentContext,
+        didFailToLoadWithError error: Error
+    ) {
+        self.presentAlert(for: error)
+    }
+
+    func paymentContext(
+        _ paymentContext: STPPaymentContext,
+        didCreatePaymentResult paymentResult: STPPaymentResult,
+        completion: @escaping STPPaymentStatusBlock
+    ) {
+
+    }
+
+    func paymentContext(
+        _ paymentContext: STPPaymentContext,
+        didFinishWith status: STPPaymentStatus,
+        error: Error?
+    ) {
+        switch status {
+        case .success:
+            ()
+        case .error:
+            presentAlert(for: error ?? StripeError.unknown)
+        case .userCancellation:
+            ()
+        @unknown default:
+            presentAlert(for: StripeError.unknown)
+        }
+    }
+}


### PR DESCRIPTION
- Adds (currently non-functional and not hooked up to anything) CheckoutVC and StripeController
- **Changes `GraphQLController.url` to be `internal static`** so it's accessible to outside objects (like the StripeController)
- Adds error alert helpers
- Fixes a login flow bug where the app would enter a non-functional state after the first time logging in