### PR TITLE
Feature/payment history

### DIFF
--- a/EcoSoapBank/Payment/PaymentHistoryViewController.swift
+++ b/EcoSoapBank/Payment/PaymentHistoryViewController.swift
@@ -18,6 +18,7 @@ class PaymentHistoryViewController: UIViewController {
         }
     }
 
+
     var cellWidth: CGFloat {
         paymentCollectionView.frame.size.width
     }
@@ -39,7 +40,12 @@ class PaymentHistoryViewController: UIViewController {
             switch result {
             case .success(let payments):
                 DispatchQueue.main.async {
-                    self.payments = payments
+                    var sortedPayments: [Payment] = payments
+                    sortedPayments.sort {
+                        guard let date0 = $0.invoicePeriodEndDate, let date1 = $1.invoicePeriodEndDate else { return false }
+                        return date0 > date1
+                    }
+                    self.payments = sortedPayments
                     self.isExpanded = Array(repeating: false, count: payments.count)
                 }
             case .failure(let error):

--- a/EcoSoapBank/Payment/PaymentHistoryViewController.swift
+++ b/EcoSoapBank/Payment/PaymentHistoryViewController.swift
@@ -49,7 +49,7 @@ class PaymentHistoryViewController: UIViewController {
                     self.isExpanded = Array(repeating: false, count: payments.count)
                 }
             case .failure(let error):
-                print(error.localizedDescription)
+                self.presentAlert(for: error)
             }
         })
     }

--- a/EcoSoapBank/Payment/PaymentHistoryViewController.swift
+++ b/EcoSoapBank/Payment/PaymentHistoryViewController.swift
@@ -53,11 +53,7 @@ class PaymentHistoryViewController: UIViewController {
             }
         })
     }
-
-    func setupNavBar() {
-//        view.add
-    }
-
+    
     func setupCollectionView() {
         view.addSubview(paymentCollectionView)
         paymentCollectionView.dataSource = self

--- a/EcoSoapBank/Payment/PaymentHistoryViewController.swift
+++ b/EcoSoapBank/Payment/PaymentHistoryViewController.swift
@@ -24,7 +24,7 @@ class PaymentHistoryViewController: UIViewController {
     }
     var expandedHeight: CGFloat = 200
     var notExpandedHeight: CGFloat = 80
-    var isExpanded = [Bool]()
+    var isExpanded: IndexPath?
     let cellIdentifier = "PaymentCell"
 
     override func loadView() {
@@ -33,7 +33,7 @@ class PaymentHistoryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.title = "Payment History"
+        navigationItem.title = "Payment History"
         setupCollectionView()
         guard let user = paymentController?.user, let properties = user.properties else { return }
         paymentController?.fetchPayments(forPropertyID: properties[0].id, completion: { result in
@@ -46,14 +46,13 @@ class PaymentHistoryViewController: UIViewController {
                         return date0 > date1
                     }
                     self.payments = sortedPayments
-                    self.isExpanded = Array(repeating: false, count: payments.count)
                 }
             case .failure(let error):
                 self.presentAlert(for: error)
             }
         })
     }
-    
+
     func setupCollectionView() {
         view.addSubview(paymentCollectionView)
         paymentCollectionView.dataSource = self
@@ -80,10 +79,11 @@ extension PaymentHistoryViewController: UICollectionViewDelegate {
     }
 
     func toggleExpandCell(indexPath: IndexPath) {
-        if !isExpanded[indexPath.row] {
-            isExpanded = Array(repeating: false, count: payments.count)
+        if let index = isExpanded, index == indexPath {
+            isExpanded = nil
+        } else {
+        isExpanded = indexPath
         }
-        isExpanded[indexPath.row].toggle()
         self.paymentCollectionView.reloadData()
     }
 }
@@ -101,7 +101,7 @@ extension PaymentHistoryViewController: UICollectionViewDataSource {
             withReuseIdentifier: cellIdentifier,
             for: indexPath) as? PaymentHistoryCollectionViewCell
             else { return UICollectionViewCell() }
-        cell.isExpanded = isExpanded[indexPath.row]
+        cell.isExpanded = isExpanded == indexPath ? true : false
         cell.payment = payments[indexPath.row]
 
         cell.layer.borderColor = UIColor.gray.cgColor
@@ -114,7 +114,7 @@ extension PaymentHistoryViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView,
                         layout collectionViewLayout: UICollectionViewLayout,
                         sizeForItemAt indexPath: IndexPath) -> CGSize {
-        isExpanded[indexPath.row] ? CGSize(width: cellWidth, height: expandedHeight) :
+        isExpanded == indexPath ? CGSize(width: cellWidth, height: expandedHeight) :
             CGSize(width: cellWidth, height: notExpandedHeight)
     }
 }


### PR DESCRIPTION
## What's here (& why)
- Small PR just added alert instead of print statement if paymentController fails to return array of payments for better communication with user and sorted payments array by invoice end date if array of payments was returned. 
- changed isExpanded to be an IndexPath

(include link(s) to applicable Trello card(s))

- 

