### PR TITLE
Feature/current property

### DIFF
--- a/EcoSoapBank/Helpers/Errors.swift
+++ b/EcoSoapBank/Helpers/Errors.swift
@@ -9,6 +9,13 @@
 import Foundation
 
 
+enum ESBError: Error {
+    case noResult
+    case noDelegate
+    case unknown
+}
+
+
 struct CustomError: LocalizedError {
     let errorDescription: String
     let recoverySuggestion: String

--- a/EcoSoapBank/Model/ImpactStats.swift
+++ b/EcoSoapBank/Model/ImpactStats.swift
@@ -15,4 +15,37 @@ struct ImpactStats: Decodable {
     let paperRecycled: Int?
     let peopleServed: Int?
     let womenEmployed: Int?
+
+    init(
+        soapRecycled: Int? = nil,
+        bottlesRecycled: Int? = nil,
+        linensRecycled: Int? = nil,
+        paperRecycled: Int? = nil,
+        peopleServed: Int? = nil,
+        womenEmployed: Int? = nil
+    ) {
+        self.soapRecycled = soapRecycled
+        self.bottlesRecycled = bottlesRecycled
+        self.linensRecycled = linensRecycled
+        self.paperRecycled = paperRecycled
+        self.peopleServed = peopleServed
+        self.womenEmployed = womenEmployed
+    }
+
+    static func + (lhs: ImpactStats, rhs: ImpactStats) -> ImpactStats {
+        ImpactStats(
+            soapRecycled: lhs.soapRecycled + rhs.soapRecycled,
+            bottlesRecycled: lhs.bottlesRecycled + rhs.bottlesRecycled,
+            linensRecycled: lhs.linensRecycled + rhs.linensRecycled,
+            paperRecycled: lhs.paperRecycled + rhs.paperRecycled,
+            peopleServed: lhs.peopleServed + rhs.peopleServed,
+            womenEmployed: lhs.womenEmployed + rhs.womenEmployed)
+    }
+}
+
+
+private extension Optional where Wrapped == Int {
+    static func + (lhs: Int?, rhs: Int?) -> Int? {
+        (lhs == nil && rhs == nil) ? nil : (lhs ?? 0) + (rhs ?? 0)
+    }
 }

--- a/EcoSoapBank/Payment/PaymentController.swift
+++ b/EcoSoapBank/Payment/PaymentController.swift
@@ -49,7 +49,7 @@ class PaymentController {
                     self?.fetchPayments(forPropertyID: propertyID, completion: promise)
                 }
             }).publisher
-            .mapError { _ in PickupError.unknown }
+            .mapError { _ in ESBError.unknown }
             .flatMap { $0 }
             .collect()
             .map { arrays in arrays.flatMap { $0 } }

--- a/EcoSoapBank/Payment/PaymentHistoryViewController.swift
+++ b/EcoSoapBank/Payment/PaymentHistoryViewController.swift
@@ -102,12 +102,12 @@ extension PaymentHistoryViewController: UICollectionViewDelegate {
         toggleExpandCell(indexPath: indexPath)
     }
 
-    /// Method to control toggle isExpanded and reload paymentCollectionView based on the results. 
+    /// Method to control toggle isExpanded and reload paymentCollectionView based on the results.
     func toggleExpandCell(indexPath: IndexPath) {
         if let index = isExpanded, index == indexPath {
             isExpanded = nil
         } else {
-        isExpanded = indexPath
+            isExpanded = indexPath
         }
         self.paymentCollectionView.reloadData()
     }

--- a/EcoSoapBank/Payment/PaymentHistoryViewController.swift
+++ b/EcoSoapBank/Payment/PaymentHistoryViewController.swift
@@ -68,9 +68,9 @@ class PaymentHistoryViewController: UIViewController {
     }
 
     private func refreshPayments() {
-        guard let user = paymentController?.user, let properties = user.properties else { return }
+        guard let controller = paymentController else { return }
         paymentCollectionView.refreshControl?.beginRefreshing()
-        paymentController?.fetchPayments(forPropertyID: properties[0].id, completion: { [weak self] result in
+        controller.fetchPaymentsForSelectedProperty(completion: { [weak self] result in
             switch result {
             case .success(let payments):
                 var sortedPayments: [Payment] = payments

--- a/EcoSoapBank/Pickups/PickupController.swift
+++ b/EcoSoapBank/Pickups/PickupController.swift
@@ -88,7 +88,7 @@ class PickupController: ObservableObject {
         return properties
             .map { fetchPickups(forPropertyID: $0.id) }             // [Publisher<[Pickup]>]
             .publisher                                              // Publisher<[Publisher[Pickup]>]>
-            .mapError { _ in ESBError.unknown }                  // makes compiler happy?
+            .mapError { _ in ESBError.unknown }                     // makes compiler happy?
             .flatMap { $0 }                                         // [Publisher[Pickup]>] -> Publisher<[Pickup]...>
             .collect()                                              // [Pickup]... -> [[Pickup]]
             .map { arrays in arrays.flatMap { $0 } }                // [[Pickup]] -> [Pickup]

--- a/EcoSoapBank/Pickups/SchedulePickupViewModel.swift
+++ b/EcoSoapBank/Pickups/SchedulePickupViewModel.swift
@@ -58,7 +58,7 @@ extension SchedulePickupViewModel {
     func schedulePickup(_ completion: ResultHandler<Pickup.ScheduleResult>? = nil) {
         guard let delegate = delegate else {
             if let comp = completion {
-                comp(.failure(PickupError.noDelegate))
+                comp(.failure(ESBError.noDelegate))
             }
             return
         }


### PR DESCRIPTION
- Impact stats and payment history now adapt to the property selected in the profile settings
  - The combine calls in there for fetching all properties probably look pretty scary... 😅 I documented a very call doing essentially the same thing in the `PickupController` (`fetchPickupsForAllProperties`), if you want to understand what each operator is doing. Essentially it's wrapping the completion in a `Future`, putting that in an array, getting a publisher from that array, and reducing the results of all of those calls into a single result.